### PR TITLE
Add DNS for Papers

### DIFF
--- a/sibr.dev.zone
+++ b/sibr.dev.zone
@@ -6,3 +6,4 @@
 api 1800 IN CNAME api.blaseball-reference.com.
 reblase 1800 IN CNAME blase.srv.astr.cc.
 stlats 1800 IN CNAME society-for-internet-blaseball-research.github.io.
+papers 1800 IN CNAME society-for-internet-blaseball-research.github.io.


### PR DESCRIPTION
otherwise known as, "ooh, I want to try the dns thing too!"

(I think we should keep the papers repo so people adding papers don't have to fork the website, but link to the papers directly from sibr.dev)