### PR TITLE
Update sibr.dev.zone

### DIFF
--- a/sibr.dev.zone
+++ b/sibr.dev.zone
@@ -3,7 +3,7 @@
 @ 10800 IN MX 10 spool.mail.gandi.net.
 @ 10800 IN MX 50 fb.mail.gandi.net.
 @ 10800 IN TXT "v=spf1 include:_mailcust.gandi.net ?all"
-api 1800 IN CNAME api.blaseball-reference.com.
+api 1800 IN CNAME srv.astr.cc.
 reblase 1800 IN CNAME blase.srv.astr.cc.
 stlats 1800 IN CNAME society-for-internet-blaseball-research.github.io.
 papers 1800 IN CNAME society-for-internet-blaseball-research.github.io.


### PR DESCRIPTION
I've set up some proxy servers listening at `api.sibr.dev` (and for that matter, `api.srv.astr.cc` for now) with the following:

`api.sibr.dev/chronicler/` -> chronicler API (local, same server)
`api.sibr.dev/datablase/` -> `api.blaseball-reference.com`
`api.sibr.dev/proxy/` -> CORS proxy for `blaseball.com` (only GET, and only `/database/*`, `/api/getIdols` and `/api/getTribute`)

`api` currently already CNAMEs to `api.blaseball-reference.com` but the cert is broken so I don't think anyone's relying on that right now.

All endpoints have response caching with a TTL of 2 seconds (atm). may need tweaking.